### PR TITLE
Add a proof-of-concept port of Zyre to .NET Standard 2.0

### DIFF
--- a/src/NetMQ.Zyre.sln
+++ b/src/NetMQ.Zyre.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.8
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetMQ.Zyre", "NetMQ.Zyre\NetMQ.Zyre.csproj", "{4D648749-20A6-4A53-A313-F67DA1BA712E}"
 EndProject
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{208C
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SamplePeer", "Samples\SamplePeer\SamplePeer.csproj", "{06C728A8-6861-42BB-8567-1397D61A6FC2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetMQ.Zyre.Standard", "NetMQ.Zyre\NetMQ.Zyre.Standard.csproj", "{F83B9281-DE44-4A38-A2FE-19F5041B104A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -71,11 +73,26 @@ Global
 		{06C728A8-6861-42BB-8567-1397D61A6FC2}.Release|x64.Build.0 = Release|Any CPU
 		{06C728A8-6861-42BB-8567-1397D61A6FC2}.Release|x86.ActiveCfg = Release|Any CPU
 		{06C728A8-6861-42BB-8567-1397D61A6FC2}.Release|x86.Build.0 = Release|Any CPU
+		{F83B9281-DE44-4A38-A2FE-19F5041B104A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F83B9281-DE44-4A38-A2FE-19F5041B104A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F83B9281-DE44-4A38-A2FE-19F5041B104A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F83B9281-DE44-4A38-A2FE-19F5041B104A}.Debug|x64.Build.0 = Debug|Any CPU
+		{F83B9281-DE44-4A38-A2FE-19F5041B104A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F83B9281-DE44-4A38-A2FE-19F5041B104A}.Debug|x86.Build.0 = Debug|Any CPU
+		{F83B9281-DE44-4A38-A2FE-19F5041B104A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F83B9281-DE44-4A38-A2FE-19F5041B104A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F83B9281-DE44-4A38-A2FE-19F5041B104A}.Release|x64.ActiveCfg = Release|Any CPU
+		{F83B9281-DE44-4A38-A2FE-19F5041B104A}.Release|x64.Build.0 = Release|Any CPU
+		{F83B9281-DE44-4A38-A2FE-19F5041B104A}.Release|x86.ActiveCfg = Release|Any CPU
+		{F83B9281-DE44-4A38-A2FE-19F5041B104A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{06C728A8-6861-42BB-8567-1397D61A6FC2} = {208C9C0C-7DF4-4145-887C-81FCF90371AD}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DD65A201-669B-41EF-8C2A-F8B58BA0866F}
 	EndGlobalSection
 EndGlobal

--- a/src/NetMQ.Zyre/NetMQ.Zyre.Standard.csproj
+++ b/src/NetMQ.Zyre/NetMQ.Zyre.Standard.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>1.0.0-rc1</Version>
+    <Authors>NetMQ</Authors>
+    <Company>NetMQ</Company>
+    <Product>NetMQ Zyre</Product>
+    <Description>C# implementation of ZeroMQ Realtime Exchange Protocol. Automatic discovery of nodes anywhere on the network!</Description>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Copyright>Copyright 2016 Dale Brubaker and Contributors</Copyright>
+    <PackageLicenseUrl>https://github.com/NetMQ/Zyre/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/NetMQ/Zyre</PackageProjectUrl>
+    <PackageReleaseNotes>.NET Standard 2.0 port of First beta release. Feedback welcome.
+</PackageReleaseNotes>
+    <PackageTags>Zyre .NET C# ZeroMQ 0MQ CLRZMQ NetMQ Messaging ZMQ transport distributed discovery</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="NetMQ.Zyre.nuspec" />
+    <None Remove="packages.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NetMQ" Version="4.0.0.1" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
I am opening this PR to begin discussion on the port to .NET Standard. This is by no means a final implementation and is not suitable to be merged right now.

.NET Standard 2.0 is the earliest version that we can target without making code changes. We may be able to move down to .NET Standard 1.3 (Same version that NetMQ currently targets) with some development effort. 

This port exists concurrently in the same directory as the existing version and shared all source files to avoid the headache of maintaining a separate folder structure. When we're confident that this is a good direction to go, we can delete the old .csproj, rename the new one to the old name and delete a few unnecessary metadata files (packages.config, NetMQ.Zyre.nuspec, Properties/* These files are manually excluded from the new .csproj and those exclusions can also be removed).

SamplePeer and NetMQ.Zyre.Tests assemblies need to be updated to either target .NET Framework 4.6.1 (or higher) or .NET Core 2.0. The latter is preferable for cross-platform testing.

I have published this package to nuget temporarily under the name "NetMQ.Zyre.Standard", for down-stream testing. When/if this PR is merged we can publish the official package under the correct package ID and I can remove this temporary one from the listings: https://www.nuget.org/packages/NetMQ.Zyre.Standard/