### PR TITLE
Improvements to compliance with spec 36/ZRE surrounding PING and PING-OK

### DIFF
--- a/src/NetMQ.Zyre/Zyre.cs
+++ b/src/NetMQ.Zyre/Zyre.cs
@@ -431,6 +431,12 @@ namespace NetMQ.Zyre
                 case "EVASIVE":
                     OnEvasiveEvent(new ZyreEventEvasive(senderUuid, name));
                     break;
+                case "PING":
+                    OnPingEvent(new ZyreEventPing(senderUuid, name));
+                    break;
+                case "PING-OK":
+                    OnPingOkEvent(new ZyreEventPingOk(senderUuid, name));
+                    break;
                 default:
                     throw new ArgumentException(msgType);
             }
@@ -444,11 +450,25 @@ namespace NetMQ.Zyre
         public event EventHandler<ZyreEventExit> ExitEvent;
         public event EventHandler<ZyreEventStop> StopEvent;
         public event EventHandler<ZyreEventEvasive> EvasiveEvent;
+        public event EventHandler<ZyreEventPing> PingEvent;
+        public event EventHandler<ZyreEventPingOk> PingOkEvent;
 
         private void OnEvasiveEvent(ZyreEventEvasive evasiveEvent)
         {
             var temp = EvasiveEvent; // for thread safety
             temp?.Invoke(this, evasiveEvent);
+        }
+
+        private void OnPingEvent(ZyreEventPing pingEvent)
+        {
+            var temp = PingEvent; // for thread safety
+            temp?.Invoke(this, pingEvent);
+        }
+
+        private void OnPingOkEvent(ZyreEventPingOk pingOkEvent)
+        {
+            var temp = PingOkEvent; // for thread safety
+            temp?.Invoke(this, pingOkEvent);
         }
 
         private void OnExitEvent(ZyreEventExit exitEvent)

--- a/src/NetMQ.Zyre/ZyreEvents/ZyreEventPing.cs
+++ b/src/NetMQ.Zyre/ZyreEvents/ZyreEventPing.cs
@@ -1,0 +1,33 @@
+﻿/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+using System;
+
+namespace NetMQ.Zyre.ZyreEvents
+{
+    public class ZyreEventPing : EventArgs, IZyreEventHeader
+    {
+        /// <summary>
+        /// The sending peer's identity.
+        /// </summary>
+        public Guid SenderUuid => _header.SenderUuid;
+
+
+        /// <summary>
+        /// The sending peer's public name.
+        /// </summary>
+        public string SenderName => _header.SenderName;
+
+        private readonly ZyreEventHeader _header;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="senderUuid">The sending peer's identity</param>
+        /// <param name="senderName">The sending peer's public name</param>
+        public ZyreEventPing(Guid senderUuid, string senderName)
+        {
+            _header = new ZyreEventHeader(senderUuid, senderName);
+        }
+    }
+}

--- a/src/NetMQ.Zyre/ZyreEvents/ZyreEventPingOk.cs
+++ b/src/NetMQ.Zyre/ZyreEvents/ZyreEventPingOk.cs
@@ -1,0 +1,33 @@
+﻿/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+using System;
+
+namespace NetMQ.Zyre.ZyreEvents
+{
+    public class ZyreEventPingOk : EventArgs, IZyreEventHeader
+    {
+        /// <summary>
+        /// The sending peer's identity.
+        /// </summary>
+        public Guid SenderUuid => _header.SenderUuid;
+
+
+        /// <summary>
+        /// The sending peer's public name.
+        /// </summary>
+        public string SenderName => _header.SenderName;
+
+        private readonly ZyreEventHeader _header;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="senderUuid">The sending peer's identity</param>
+        /// <param name="senderName">The sending peer's public name</param>
+        public ZyreEventPingOk(Guid senderUuid, string senderName)
+        {
+            _header = new ZyreEventHeader(senderUuid, senderName);
+        }
+    }
+}

--- a/src/NetMQ.Zyre/ZyreNode.cs
+++ b/src/NetMQ.Zyre/ZyreNode.cs
@@ -820,11 +820,15 @@ namespace NetMQ.Zyre
                     Debug.Assert(msg.Leave.Status == peer.Status);
                     break;
                 case ZreMsg.MessageId.Ping:
-                    _actor.SendMoreFrame("PING-OK").SendMoreFrame(uuid.ToByteArray());
+                    // Respond to a PING request with PING-OK, always
+                    _actor.SendMoreFrame("PING-OK").SendFrame(uuid.ToByteArray());
+                    // Notify Zyre application PING came in
+                    _outbox.SendMoreFrame("PING").SendMoreFrame(uuid.ToByteArray()).SendFrame(peer.Name);
                     break;
                 case ZreMsg.MessageId.PingOk:
-                    // Good, the peer is alive, we will reset our timers 
+                	// Good, the peer is alive, we will reset our timers 
                     // with the peer.Refresh(); call below.
+                    _outbox.SendMoreFrame("PING-OK").SendMoreFrame(uuid.ToByteArray()).SendFrame(peer.Name);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
The spec states:
The PING-OK Command
When a node receives a PING command it SHALL reply with a PING-OK command.

Completed PING and PING-OK messages.  This allows the library to work with https://github.com/zeromq/zyre which is correctly expecting PING messages to trigger PING-OK responses.